### PR TITLE
Use a Railtie to avoid deprecation warnings in rails 4.2

### DIFF
--- a/spec/rails_app/Gemfile
+++ b/spec/rails_app/Gemfile
@@ -22,6 +22,8 @@ end
 
 gem 'jquery-rails'
 
+gem 'after_commit_action', path: "../"
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,12 @@ require 'rspec'
 require 'after_commit_action'
 
 load "#{File.dirname(__FILE__)}/schema.rb"
-
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  
+  config.before :suite do
+    ActiveRecord::Base.send :include, AfterCommitAction::ActiveRecord
+  end
 end


### PR DESCRIPTION
Rails 4.2 has a deprecation warning upon calling `after_commit`. In normal circumstances this is avoided by a configuration. However due to the direct injection of the after commit action module upon require `after_commit` is called /before/ those configurations can apply, thus permanently causing deprecation warnings.

This is easily solved using a Railtie to inject the module at a more appropriate time.
