### PR TITLE
Use `self.class.connection` instead of `ActiveRecord::Base.connection`

### DIFF
--- a/lib/after_commit_action.rb
+++ b/lib/after_commit_action.rb
@@ -17,10 +17,10 @@ module AfterCommitAction
   end
 
   def execute_after_commit(&block)
-    if ActiveRecord::Base.connection.open_transactions == 0
+    if self.class.connection.open_transactions == 0
       return block.call
     else
-      ActiveRecord::Base.connection.add_transaction_record(self)
+      self.class.connection.add_transaction_record(self)
     end
 
     @_execute_after_commit ||= []


### PR DESCRIPTION
### Problems
- `ActiveRecord::Base.connection` could return wrong connection if `after_commit_action` is used with [octopus](https://github.com/thiagopradi/octopus). `ActiveRecord::Base.connection` always returns a connection to shard in the sharding block.

### Changes
- Used `self.class.connection` instead of `ActiveRecord::Base.connection`. `self.class.connection` returns a connection of self class model exactly.