### PR TITLE
Change spec.homepage from HTTP to HTTPS

### DIFF
--- a/after_commit_action.gemspec
+++ b/after_commit_action.gemspec
@@ -85,7 +85,7 @@ Gem::Specification.new do |s|
     "spec/schema.rb",
     "spec/spec_helper.rb"
   ]
-  s.homepage = "http://github.com/magnusvk/after_commit_action".freeze
+  s.homepage = "https://github.com/magnusvk/after_commit_action".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "2.6.10".freeze
   s.summary = "Easily defer blocks of code to the after-commit action of an ActiveRecord model.".freeze


### PR DESCRIPTION
First of all, I would like to thank you. I have been using this Gem for a long time.

Today I happened to have a chance to look back at the `spec.homepage` of all the gems my Rails app depends on, and that's where I noticed that the link at https://rubygems.org/gems/after_commit_action redirect from HTTP to HTTPS .

![image](https://user-images.githubusercontent.com/111689/175755087-7a559eef-e6bd-42e6-b1e2-1454b17954ce.png)

GitHub now uses HTTPS by default, so I decided to send this pull request.